### PR TITLE
Use python logging instead of print to stderr.

### DIFF
--- a/YahooSports/util.py
+++ b/YahooSports/util.py
@@ -1,9 +1,0 @@
-from __future__ import absolute_import, division, print_function, unicode_literals
-from builtins import *
-
-import sys
-
-
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
-

--- a/YahooSports/yahoo_sports.py
+++ b/YahooSports/yahoo_sports.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 from builtins import *
-
+import logging
+logger = logging.getLogger(__name__)
 import json
 from os.path import isfile
 import re
@@ -13,7 +14,6 @@ import functools
 from rauth import OAuth2Service, OAuth2Session
 from requests.exceptions import ConnectionError
 
-from YahooSports.util import eprint
 from YahooSports.exceptions import OAuthExpired, OAuth401Error, NoRefreshToken
 
 
@@ -183,7 +183,7 @@ class YahooConnection(object):
         if not hasattr(self.session, 'refresh_token'):
             raise NoRefreshToken()
 
-        eprint("session expired.  refreshing.")
+        logger.info("session expired.  refreshing.")
 
         refresh_data = {'refresh_token': "{}".format(self.session.refresh_token),
                         'grant_type': 'refresh_token',


### PR DESCRIPTION
* Printing to stderr isn't ideal when using YahooSports from a terminal user
  interface that draws on the screen using urwid or curses.
* Python logging can easily be configured to log to the console, log files, etc.